### PR TITLE
Fix MediaPipe Face Landmarker builder method usage

### DIFF
--- a/app/src/main/java/com/drivesense/drivesense/DriveSenseAnalyzer.kt
+++ b/app/src/main/java/com/drivesense/drivesense/DriveSenseAnalyzer.kt
@@ -58,7 +58,7 @@ class DriveSenseAnalyzer(
             .setRunningMode(RunningMode.VIDEO)
             .setNumFaces(1)
             .setMinFaceDetectionConfidence(0.5f)
-            .setMinFaceTrackingConfidence(0.5f)
+            .setMinTrackingConfidence(0.5f)
             .setMinFacePresenceConfidence(0.5f)
             .build()
         FaceLandmarker.createFromOptions(context, options)


### PR DESCRIPTION
## Summary
- replace the nonexistent `setMinFaceTrackingConfidence` call with the correct `setMinTrackingConfidence` builder option when configuring the MediaPipe Face Landmarker

## Testing
- `./gradlew --console=plain :app:compileDebugKotlin` *(fails: SDK location not set in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d85d5f512483268498d177fffb50ed