### PR TITLE
Switch driving detection to Activity Recognition API

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -89,6 +89,7 @@ dependencies {
 
     implementation 'com.google.mlkit:face-detection:16.1.5'
     implementation 'com.google.mediapipe:tasks-vision:0.10.14'
+    implementation 'com.google.android.gms:play-services-location:21.3.0'
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.2.1'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.VIBRATE" />
 


### PR DESCRIPTION
## Summary
- add the Play Services activity recognition dependency and permission required for driving detection
- replace the sensor-based DrivingStatusMonitor with the Activity Recognition Transition API
- request runtime activity recognition permission in MainActivity before starting monitoring

## Testing
- ./gradlew assembleDebug *(fails: Android SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8666519188326932dc547aaf5d265