### PR TITLE
Add rear camera road detection with overlay

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -88,6 +88,7 @@ dependencies {
     implementation 'androidx.camera:camera-view:1.3.4'
 
     implementation 'com.google.mlkit:face-detection:16.1.5'
+    implementation 'com.google.mlkit:object-detection:17.0.0'
     implementation 'com.google.mediapipe:tasks-vision:0.10.14'
     implementation 'com.google.android.gms:play-services-location:21.3.0'
 

--- a/app/src/main/java/com/drivesense/drivesense/RoadObjectAnalyzer.kt
+++ b/app/src/main/java/com/drivesense/drivesense/RoadObjectAnalyzer.kt
@@ -1,0 +1,123 @@
+package com.drivesense.drivesense
+
+import android.graphics.Rect
+import android.graphics.RectF
+import androidx.camera.core.ImageAnalysis
+import androidx.camera.core.ImageProxy
+import com.drivesense.drivesense.ui.DetectionOverlayView.RoadObjectDetection
+import com.google.mlkit.vision.common.InputImage
+import com.google.mlkit.vision.objects.DetectedObject
+import com.google.mlkit.vision.objects.ObjectDetector
+import java.util.Locale
+import java.util.concurrent.Executor
+
+class RoadObjectAnalyzer(
+    private val detector: ObjectDetector,
+    private val mainExecutor: Executor,
+    private val onDetectionsUpdated: (List<RoadObjectDetection>) -> Unit
+) : ImageAnalysis.Analyzer {
+
+    override fun analyze(imageProxy: ImageProxy) {
+        val mediaImage = imageProxy.image ?: run {
+            imageProxy.close()
+            return
+        }
+
+        val rotationDegrees = imageProxy.imageInfo.rotationDegrees
+        val image = InputImage.fromMediaImage(mediaImage, rotationDegrees)
+        val imageWidth = imageProxy.width
+        val imageHeight = imageProxy.height
+
+        detector
+            .process(image)
+            .addOnSuccessListener { detectedObjects ->
+                val detections = detectedObjects.mapNotNull { detectedObject ->
+                    val label = detectedObject.classificationLabel() ?: return@mapNotNull null
+                    val bounds = detectedObject.boundingBox.toNormalizedBounds(
+                        imageWidth,
+                        imageHeight,
+                        rotationDegrees
+                    ) ?: return@mapNotNull null
+                    RoadObjectDetection(bounds, label)
+                }
+                mainExecutor.execute { onDetectionsUpdated(detections) }
+            }
+            .addOnFailureListener {
+                mainExecutor.execute { onDetectionsUpdated(emptyList()) }
+            }
+            .addOnCompleteListener {
+                imageProxy.close()
+            }
+    }
+
+    private fun DetectedObject.classificationLabel(): String? {
+        val label = labels
+            .filter { it.confidence >= MIN_CONFIDENCE }
+            .maxByOrNull { it.confidence }
+            ?: return null
+        val normalizedLabel = label.text.lowercase(Locale.US)
+        val match = when {
+            normalizedLabel.contains("person") || normalizedLabel.contains("pedestrian") -> "Pedestrian"
+            normalizedLabel.contains("cat") || normalizedLabel.contains("dog") || normalizedLabel.contains("animal") -> "Animal"
+            normalizedLabel.contains("car") || normalizedLabel.contains("vehicle") ||
+                normalizedLabel.contains("bus") || normalizedLabel.contains("truck") ||
+                normalizedLabel.contains("bike") || normalizedLabel.contains("bicycle") ||
+                normalizedLabel.contains("motorcycle") -> "Vehicle"
+            else -> null
+        }
+        return match
+    }
+
+    private fun Rect.toNormalizedBounds(
+        imageWidth: Int,
+        imageHeight: Int,
+        rotationDegrees: Int
+    ): RectF? {
+        if (width() <= 0 || height() <= 0) {
+            return null
+        }
+        val (normalizedLeft, normalizedTop, normalizedRight, normalizedBottom) = when (rotationDegrees) {
+            0 -> listOf(
+                left / imageWidth.toFloat(),
+                top / imageHeight.toFloat(),
+                right / imageWidth.toFloat(),
+                bottom / imageHeight.toFloat()
+            )
+            90 -> listOf(
+                top / imageHeight.toFloat(),
+                (imageWidth - right) / imageWidth.toFloat(),
+                bottom / imageHeight.toFloat(),
+                (imageWidth - left) / imageWidth.toFloat()
+            )
+            180 -> listOf(
+                (imageWidth - right) / imageWidth.toFloat(),
+                (imageHeight - bottom) / imageHeight.toFloat(),
+                (imageWidth - left) / imageWidth.toFloat(),
+                (imageHeight - top) / imageHeight.toFloat()
+            )
+            270 -> listOf(
+                (imageHeight - bottom) / imageHeight.toFloat(),
+                left / imageWidth.toFloat(),
+                (imageHeight - top) / imageHeight.toFloat(),
+                right / imageWidth.toFloat()
+            )
+            else -> listOf(
+                left / imageWidth.toFloat(),
+                top / imageHeight.toFloat(),
+                right / imageWidth.toFloat(),
+                bottom / imageHeight.toFloat()
+            )
+        }
+
+        val leftClamped = normalizedLeft.coerceIn(0f, 1f)
+        val topClamped = normalizedTop.coerceIn(0f, 1f)
+        val rightClamped = normalizedRight.coerceIn(0f, 1f)
+        val bottomClamped = normalizedBottom.coerceIn(0f, 1f)
+
+        return RectF(leftClamped, topClamped, rightClamped, bottomClamped)
+    }
+
+    companion object {
+        private const val MIN_CONFIDENCE = 0.4f
+    }
+}

--- a/app/src/main/java/com/drivesense/drivesense/ui/DetectionOverlayView.kt
+++ b/app/src/main/java/com/drivesense/drivesense/ui/DetectionOverlayView.kt
@@ -1,0 +1,95 @@
+package com.drivesense.drivesense.ui
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.RectF
+import android.util.AttributeSet
+import android.view.View
+import androidx.core.graphics.withSave
+import java.util.concurrent.CopyOnWriteArrayList
+
+class DetectionOverlayView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : View(context, attrs, defStyleAttr) {
+
+    private val boxPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.parseColor("#4CAF50")
+        style = Paint.Style.STROKE
+        strokeWidth = 6f
+    }
+
+    private val textPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.WHITE
+        textSize = 42f
+        style = Paint.Style.FILL
+    }
+
+    private val backgroundPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.parseColor("#66000000")
+        style = Paint.Style.FILL
+    }
+
+    private val detections = CopyOnWriteArrayList<RoadObjectDetection>()
+
+    fun updateDetections(newDetections: List<RoadObjectDetection>) {
+        detections.clear()
+        detections.addAll(newDetections)
+        postInvalidateOnAnimation()
+    }
+
+    fun clearDetections() {
+        detections.clear()
+        postInvalidateOnAnimation()
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+        if (detections.isEmpty()) return
+
+        val width = width.toFloat()
+        val height = height.toFloat()
+
+        canvas.withSave {
+            detections.forEach { detection ->
+                val rect = RectF(
+                    detection.bounds.left * width,
+                    detection.bounds.top * height,
+                    detection.bounds.right * width,
+                    detection.bounds.bottom * height
+                )
+
+                canvas.drawRect(rect, boxPaint)
+
+                val label = detection.label
+                if (label.isNotEmpty()) {
+                    val textPadding = 8f
+                    val textWidth = textPaint.measureText(label)
+                    val textHeight = textPaint.textSize
+                    val backgroundTop = (rect.top - textHeight - textPadding * 2).coerceAtLeast(0f)
+                    val backgroundRect = RectF(
+                        rect.left,
+                        backgroundTop,
+                        rect.left + textWidth + textPadding * 2,
+                        backgroundTop + textHeight + textPadding * 2
+                    )
+                    canvas.drawRoundRect(backgroundRect, 12f, 12f, backgroundPaint)
+                    canvas.drawText(
+                        label,
+                        backgroundRect.left + textPadding,
+                        backgroundRect.bottom - textPadding,
+                        textPaint
+                    )
+                }
+            }
+        }
+    }
+
+    data class RoadObjectDetection(
+        val bounds: RectF,
+        val label: String
+    )
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -7,15 +7,54 @@
     android:background="@android:color/black"
     tools:context=".MainActivity">
 
-    <androidx.camera.view.PreviewView
-        android:id="@+id/viewFinder"
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/midGuideline"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.5" />
+
+    <FrameLayout
+        android:id="@+id/frontPreviewContainer"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:keepScreenOn="true"
+        app:layout_constraintBottom_toTopOf="@id/midGuideline"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <androidx.camera.view.PreviewView
+            android:id="@+id/frontViewFinder"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:keepScreenOn="true"
+            app:implementationMode="compatible" />
+
+    </FrameLayout>
+
+    <FrameLayout
+        android:id="@+id/rearPreviewContainer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toBottomOf="@id/midGuideline">
+
+        <androidx.camera.view.PreviewView
+            android:id="@+id/rearViewFinder"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:keepScreenOn="true"
+            app:implementationMode="compatible" />
+
+        <com.drivesense.drivesense.ui.DetectionOverlayView
+            android:id="@+id/rearOverlay"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_gravity="center" />
+
+    </FrameLayout>
 
     <TextView
         android:id="@+id/statusText"
@@ -59,6 +98,17 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/drivingCheckSwitch" />
+
+    <com.google.android.material.switchmaterial.SwitchMaterial
+        android:id="@+id/roadDetectionSwitch"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:text="@string/label_enable_road_detection"
+        android:textColor="@android:color/white"
+        app:layout_constraintBottom_toTopOf="@id/lastEventText"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
 
     <TextView
         android:id="@+id/lastEventText"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
     <string name="event_last_alert">Last alert: %1$s</string>
     <string name="status_error">Camera offline. Please restart DriveSense.</string>
     <string name="label_require_driving">Require driving detection</string>
+    <string name="label_enable_road_detection">Enable road object detection</string>
     <string name="status_waiting_for_driving">Waiting for vehicle motion…</string>
     <string name="status_driving_detection_unavailable">Driving detection unavailable. Disable the driving check to continue.</string>
     <string name="status_driving_detected">Driving detected</string>


### PR DESCRIPTION
## Summary
- split the driving preview into front and rear panes with a rear overlay view
- add an ML Kit powered road object analyzer to highlight vehicles, pedestrians, and animals when enabled
- introduce a user preference toggle and supporting resources for road object detection

## Testing
- `./gradlew lint` *(fails: SDK location not configured in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8ead1bad883268e31ffca00ee0d5d