### PR TITLE
Fix ManualLifecycleOwner lifecycle implementation

### DIFF
--- a/app/src/main/java/com/drivesense/drivesense/MainActivity.kt
+++ b/app/src/main/java/com/drivesense/drivesense/MainActivity.kt
@@ -439,7 +439,8 @@ class MainActivity : AppCompatActivity() {
 private class ManualLifecycleOwner : LifecycleOwner {
     private val lifecycleRegistry = LifecycleRegistry(this)
 
-    override fun getLifecycle(): Lifecycle = lifecycleRegistry
+    override val lifecycle: Lifecycle
+        get() = lifecycleRegistry
 
     fun onCreate() {
         lifecycleRegistry.currentState = Lifecycle.State.CREATED


### PR DESCRIPTION
## Summary
- override the `lifecycle` property in `ManualLifecycleOwner` to satisfy the `LifecycleOwner` interface contract

## Testing
- ./gradlew :app:assembleDebug *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d91b4f63548326b0a213fc138302b2