### PR TITLE
Fix road detection support check

### DIFF
--- a/app/src/main/java/com/drivesense/drivesense/MainActivity.kt
+++ b/app/src/main/java/com/drivesense/drivesense/MainActivity.kt
@@ -434,9 +434,12 @@ class MainActivity : AppCompatActivity() {
 
     private fun ProcessCameraProvider.isConcurrentCameraModeSupportedCompat(): Boolean {
         return try {
-            val method = ProcessCameraProvider::class.java.getMethod("isConcurrentCameraModeSupported")
-            method.invoke(this) as? Boolean ?: false
-        } catch (_: NoSuchMethodException) {
+            isConcurrentCameraModeSupported(
+                CameraSelector.DEFAULT_FRONT_CAMERA,
+                CameraSelector.DEFAULT_BACK_CAMERA
+            )
+        } catch (error: NoSuchMethodError) {
+            Log.w(TAG, "Concurrent camera mode support check unavailable", error)
             false
         } catch (exception: Exception) {
             Log.w(TAG, "Unable to query concurrent camera mode support", exception)


### PR DESCRIPTION
## Summary
- call the concurrent camera support query with the correct parameters so dual-camera capable devices are detected
- add logging when the support query method is unavailable at runtime

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d942673e448326a43cb522a7d813fc