### PR TITLE
Fix concurrent camera support check

### DIFF
--- a/app/src/main/java/com/drivesense/drivesense/MainActivity.kt
+++ b/app/src/main/java/com/drivesense/drivesense/MainActivity.kt
@@ -434,10 +434,19 @@ class MainActivity : AppCompatActivity() {
 
     private fun ProcessCameraProvider.isConcurrentCameraModeSupportedCompat(): Boolean {
         return try {
-            isConcurrentCameraModeSupported(
+            val method = ProcessCameraProvider::class.java.getMethod(
+                "isConcurrentCameraModeSupported",
+                CameraSelector::class.java,
+                CameraSelector::class.java
+            )
+            method.invoke(
+                this,
                 CameraSelector.DEFAULT_FRONT_CAMERA,
                 CameraSelector.DEFAULT_BACK_CAMERA
-            )
+            ) as Boolean
+        } catch (error: NoSuchMethodException) {
+            Log.w(TAG, "Concurrent camera mode support check unavailable", error)
+            false
         } catch (error: NoSuchMethodError) {
             Log.w(TAG, "Concurrent camera mode support check unavailable", error)
             false


### PR DESCRIPTION
## Summary
- replace direct call to ProcessCameraProvider.isConcurrentCameraModeSupported with a reflection-based invocation
- add compatibility handling for environments where the API is not available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d964b338008326a75189097ff855e7