### PR TITLE
Fix PreviewView property usage for camera initialization

### DIFF
--- a/app/src/main/java/com/drivesense/drivesense/MainActivity.kt
+++ b/app/src/main/java/com/drivesense/drivesense/MainActivity.kt
@@ -101,11 +101,11 @@ class MainActivity : AppCompatActivity() {
         frontCameraLifecycleOwner.onCreate()
         rearCameraLifecycleOwner.onCreate()
 
-        binding.frontViewFinder.preferredImplementationMode =
+        binding.frontViewFinder.implementationMode =
             androidx.camera.view.PreviewView.ImplementationMode.COMPATIBLE
         binding.frontViewFinder.scaleType =
             androidx.camera.view.PreviewView.ScaleType.FILL_CENTER
-        binding.rearViewFinder.preferredImplementationMode =
+        binding.rearViewFinder.implementationMode =
             androidx.camera.view.PreviewView.ImplementationMode.COMPATIBLE
         binding.rearViewFinder.scaleType =
             androidx.camera.view.PreviewView.ScaleType.FILL_CENTER


### PR DESCRIPTION
## Summary
- replace the use of the non-existent `preferredImplementationMode` property with the supported `implementationMode` setter on both preview views

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d976fbbfc8832688502be64ee882a0