### PR TITLE
Fix ViewPort builder aspect ratio initialization

### DIFF
--- a/app/src/main/java/com/drivesense/drivesense/MainActivity.kt
+++ b/app/src/main/java/com/drivesense/drivesense/MainActivity.kt
@@ -13,6 +13,7 @@ import android.os.SystemClock
 import android.os.VibrationEffect
 import android.os.Vibrator
 import android.util.Log
+import android.util.Rational
 import android.util.Size
 import android.view.Surface
 import android.view.View
@@ -297,10 +298,9 @@ class MainActivity : AppCompatActivity() {
         imageAnalysis.setAnalyzer(cameraExecutor, analyzer!!)
 
         val frontViewport = ViewPort.Builder(
-            binding.frontViewFinder.width,
-            binding.frontViewFinder.height,
+            Rational(binding.frontViewFinder.width, binding.frontViewFinder.height),
             binding.frontViewFinder.display?.rotation ?: Surface.ROTATION_0
-        ).setAspectRatio(AspectRatio.RATIO_4_3).build()
+        ).build()
 
         val frontGroup = UseCaseGroup.Builder()
             .addUseCase(frontPreview)
@@ -341,10 +341,9 @@ class MainActivity : AppCompatActivity() {
         val rearCameraSelector = getRearCameraSelector()
 
         val rearViewport = ViewPort.Builder(
-            binding.rearViewFinder.width,
-            binding.rearViewFinder.height,
+            Rational(binding.rearViewFinder.width, binding.rearViewFinder.height),
             binding.rearViewFinder.display?.rotation ?: Surface.ROTATION_0
-        ).setAspectRatio(AspectRatio.RATIO_4_3).build()
+        ).build()
 
         val rearGroupBuilder = UseCaseGroup.Builder()
             .addUseCase(rearPreview)


### PR DESCRIPTION
## Summary
- update ViewPort.Builder usage to supply a Rational aspect ratio and rotation only
- add Rational import required by the new builder signature

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: SDK location not configured in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d977c3c58c83268f21213d8502b3df