### PR TITLE
Fix reflection lookup for CameraMode class

### DIFF
--- a/app/src/main/java/com/drivesense/drivesense/MainActivity.kt
+++ b/app/src/main/java/com/drivesense/drivesense/MainActivity.kt
@@ -558,7 +558,7 @@ class MainActivity : AppCompatActivity() {
 
     private fun ViewPort.Builder.setConcurrentCameraModeCompat() {
         try {
-            val cameraModeClass = Class.forName("androidx.camera.core.ViewPort$CameraMode")
+            val cameraModeClass = Class.forName("androidx.camera.core.ViewPort\$CameraMode")
             val concurrentField = cameraModeClass.getField("CONCURRENT")
             val concurrentValue = concurrentField.get(null)
             val method = ViewPort.Builder::class.java.getMethod("setCameraMode", cameraModeClass)


### PR DESCRIPTION
## Summary
- escape the dollar sign in the ViewPort CameraMode reflection lookup to prevent Kotlin string interpolation errors

## Testing
- ./gradlew compileDebugKotlin *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d97d94696c8326a254cd90d8d76498