### PR TITLE
Add compatibility shim for concurrent camera viewport

### DIFF
--- a/app/src/main/java/com/drivesense/drivesense/MainActivity.kt
+++ b/app/src/main/java/com/drivesense/drivesense/MainActivity.kt
@@ -234,13 +234,25 @@ class MainActivity : AppCompatActivity() {
             Rational(previewView.width, previewView.height),
             previewView.display?.rotation ?: Surface.ROTATION_0
         )
-        return builder
-            .apply {
-                if (supportsConcurrentCameras) {
-                    setCameraMode(ViewPort.CameraMode.CONCURRENT)
-                }
-            }
-            .build()
+        if (supportsConcurrentCameras) {
+            setConcurrentCameraModeIfAvailable(builder)
+        }
+        return builder.build()
+    }
+
+    private fun setConcurrentCameraModeIfAvailable(builder: ViewPort.Builder) {
+        try {
+            val cameraModeClass = Class.forName("androidx.camera.core.ViewPort\$CameraMode")
+            val concurrentMode = cameraModeClass.getField("CONCURRENT").get(null)
+            val method = ViewPort.Builder::class.java.getMethod("setCameraMode", cameraModeClass)
+            method.invoke(builder, concurrentMode)
+        } catch (error: ClassNotFoundException) {
+            Log.w(TAG, "ViewPort.CameraMode class unavailable, cannot request concurrent camera mode")
+        } catch (error: NoSuchMethodException) {
+            Log.w(TAG, "setCameraMode method unavailable on ViewPort.Builder")
+        } catch (error: Exception) {
+            Log.w(TAG, "Unable to set concurrent camera mode", error)
+        }
     }
 
     private fun bindUseCasesInternal(provider: ProcessCameraProvider) {


### PR DESCRIPTION
## Summary
- stop referencing ViewPort concurrent camera APIs that are unavailable in older CameraX releases
- set the concurrent camera mode via reflection when supported and log a warning otherwise

## Testing
- not run (Android SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d98043e4088326bb7c7e16fb248e51