### PR TITLE
Enable CameraX concurrent viewport support

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -74,6 +74,8 @@ tasks.register('downloadFaceLandmarkerModel') {
 
 preBuild.dependsOn downloadFaceLandmarkerModel
 
+def cameraxVersion = "1.4.1"
+
 dependencies {
     implementation 'androidx.core:core-ktx:1.13.1'
     implementation 'androidx.appcompat:appcompat:1.7.0'
@@ -82,10 +84,10 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.8.3'
     implementation 'androidx.activity:activity-ktx:1.9.2'
 
-    implementation 'androidx.camera:camera-core:1.4.0'
-    implementation 'androidx.camera:camera-camera2:1.4.0'
-    implementation 'androidx.camera:camera-lifecycle:1.4.0'
-    implementation 'androidx.camera:camera-view:1.4.0'
+    implementation "androidx.camera:camera-core:$cameraxVersion"
+    implementation "androidx.camera:camera-camera2:$cameraxVersion"
+    implementation "androidx.camera:camera-lifecycle:$cameraxVersion"
+    implementation "androidx.camera:camera-view:$cameraxVersion"
 
     implementation 'com.google.mlkit:face-detection:16.1.5'
     implementation 'com.google.mlkit:object-detection:17.0.0'

--- a/app/src/main/java/com/drivesense/drivesense/MainActivity.kt
+++ b/app/src/main/java/com/drivesense/drivesense/MainActivity.kt
@@ -230,29 +230,14 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun createViewPort(previewView: PreviewView): ViewPort {
-        val builder = ViewPort.Builder(
+        return ViewPort.Builder(
             Rational(previewView.width, previewView.height),
             previewView.display?.rotation ?: Surface.ROTATION_0
-        )
-        if (supportsConcurrentCameras) {
-            setConcurrentCameraModeIfAvailable(builder)
-        }
-        return builder.build()
-    }
-
-    private fun setConcurrentCameraModeIfAvailable(builder: ViewPort.Builder) {
-        try {
-            val cameraModeClass = Class.forName("androidx.camera.core.ViewPort\$CameraMode")
-            val concurrentMode = cameraModeClass.getField("CONCURRENT").get(null)
-            val method = ViewPort.Builder::class.java.getMethod("setCameraMode", cameraModeClass)
-            method.invoke(builder, concurrentMode)
-        } catch (error: ClassNotFoundException) {
-            Log.w(TAG, "ViewPort.CameraMode class unavailable, cannot request concurrent camera mode")
-        } catch (error: NoSuchMethodException) {
-            Log.w(TAG, "setCameraMode method unavailable on ViewPort.Builder")
-        } catch (error: Exception) {
-            Log.w(TAG, "Unable to set concurrent camera mode", error)
-        }
+        ).apply {
+            if (supportsConcurrentCameras) {
+                setCameraMode(ViewPort.CameraMode.CONCURRENT)
+            }
+        }.build()
     }
 
     private fun bindUseCasesInternal(provider: ProcessCameraProvider) {


### PR DESCRIPTION
## Summary
- update CameraX dependencies to version 1.4.1 using a shared version constant
- request ViewPort concurrent mode via the direct API when multiple cameras are supported

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d985774418832686157a06136095ac