### PR TITLE
Handle multi-face driver selection overlay

### DIFF
--- a/app/src/main/java/com/drivesense/drivesense/MainActivity.kt
+++ b/app/src/main/java/com/drivesense/drivesense/MainActivity.kt
@@ -289,7 +289,11 @@ class MainActivity : AppCompatActivity() {
             context = applicationContext,
             detector = faceDetector!!,
             mainExecutor = mainThreadExecutor,
-            onStateUpdated = ::handleDriverState
+            onStateUpdated = ::handleDriverState,
+            onDriverFaceUpdated = { bounds ->
+                binding.frontFaceOverlay.updateBounds(bounds)
+            },
+            mirrorPreview = true
         )
 
         if (supportsConcurrentCameras && roadDetectionEnabled) {

--- a/app/src/main/java/com/drivesense/drivesense/ui/FaceSelectionOverlayView.kt
+++ b/app/src/main/java/com/drivesense/drivesense/ui/FaceSelectionOverlayView.kt
@@ -1,0 +1,65 @@
+package com.drivesense.drivesense.ui
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.RectF
+import android.util.AttributeSet
+import android.view.View
+import androidx.core.graphics.withSave
+
+class FaceSelectionOverlayView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : View(context, attrs, defStyleAttr) {
+
+    private val boxPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.parseColor("#FFB300")
+        style = Paint.Style.STROKE
+        strokeWidth = 6f
+    }
+
+    private val bounds = RectF()
+    @Volatile
+    private var hasBounds: Boolean = false
+
+    fun updateBounds(newBounds: RectF?) {
+        if (newBounds == null) {
+            if (!hasBounds) {
+                return
+            }
+            hasBounds = false
+            postInvalidateOnAnimation()
+            return
+        }
+
+        bounds.set(newBounds)
+        hasBounds = true
+        postInvalidateOnAnimation()
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+        if (!hasBounds) {
+            return
+        }
+
+        val width = width.toFloat()
+        val height = height.toFloat()
+        if (width <= 0f || height <= 0f) {
+            return
+        }
+
+        canvas.withSave {
+            val rect = RectF(
+                bounds.left * width,
+                bounds.top * height,
+                bounds.right * width,
+                bounds.bottom * height
+            )
+            canvas.drawRect(rect, boxPaint)
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -31,6 +31,12 @@
             app:implementationMode="performance"
             app:scaleType="fitCenter" />
 
+        <com.drivesense.drivesense.ui.FaceSelectionOverlayView
+            android:id="@+id/frontFaceOverlay"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_gravity="center" />
+
     </FrameLayout>
 
     <FrameLayout


### PR DESCRIPTION
## Summary
- prioritize the closest detected face during driver state evaluation and keep MediaPipe metrics aligned
- publish normalized bounding boxes and draw the selected driver face in a dedicated overlay
- expose the analyzer face updates to the activity and front preview layout

## Testing
- `./gradlew lint` *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd5d4d6de0832698a0966a6d5679a2